### PR TITLE
Add support for running PICO-8 from Emacs

### DIFF
--- a/README.org
+++ b/README.org
@@ -28,6 +28,10 @@
    to force a rebuild. This happens automatically when the mode is
    loaded.
 
+   To be able to run PICO-8 from Emacs, set the *pico8-executable-path* variable
+   to the =pico8= executable. E.g. =~/Downloads/pico-8/pico8=. Call
+   *pico8-run-cartridge* and *pico8-kill-process* respectively.
+
 *** Requirements
 
    - [[https://github.com/immerrr/lua-mode][lua-mode]]

--- a/pico8-mode.el
+++ b/pico8-mode.el
@@ -65,6 +65,11 @@ Enables documentation annotations with eldoc and company"
   :type 'boolean
   :group 'pico8)
 
+(defcustom pico8-executable-path ""
+  "Full path to pico8 executable."
+  :type 'file
+  :group 'pico8)
+
 (defface pico8--non-lua-overlay
   '((((background light)) :foreground "grey90")
     (((background dark)) :foreground "grey10"))
@@ -587,6 +592,32 @@ region."
     (when pico8--lua-block-end
       (pico8--put-non-lua-overlay pico8--lua-block-end (point-max)))
     ))
+
+(defvar pico8--process nil
+  "The currently running PICO-8 process")
+
+(defun pico8--process-running? ()
+  "Return t if a PICO-8 process is already running"
+  (when pico8--process
+    (eq (process-status pico8--process)
+        'run)))
+
+(defun pico8--confirm-and-kill-process ()
+  (when (y-or-n-p "PICO-8 is already running. Kill process?")
+    (pico8-kill-process)))
+
+(defun pico8-run-cartridge ()
+  "Run the file visited by the current buffer as PICO-8 cartridge"
+  (interactive)
+  (when (pico8--process-running?)
+    (pico8--confirm-and-kill-process))
+  (setq pico8--process (start-process "pico8-process" "pico8-output"
+                                      pico8-executable-path "-run" (buffer-file-name))))
+
+(defun pico8-kill-process ()
+  "Kill the currently running PICO-8 process by sending SIGQUIT"
+  (interactive)
+  (quit-process pico8--process))
 
 ;;;###autoload
 (define-derived-mode pico8-mode lua-mode "pico8"


### PR DESCRIPTION
Hey @Kaali, thank you for publishing this major mode. Very helpful! I liked the idea of starting PICO-8 from Emacs(#5) and gave the implementation a shot. Let me know what you think!

## Description

Adds a new customizable variable to set the path to the PICO-8 executable and functions to run the currently visited file as cartridge.

Tested with Emacs 28.2 and PICO-8 v0.2.5g

## Known issues:
* Only keeps track of one PICO-8 process. Starting additional PICO-8 processes from Emacs will cause them to write to the same buffer, potentially causing confusion.

